### PR TITLE
removed text decoration when hover

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -62,6 +62,10 @@
   }
 }
 
+a:hover {
+  text-decoration: none;
+}
+
 .card-trip {
   overflow: hidden;
   background: white;


### PR DESCRIPTION
## Why
​
This pull request is needed because:
Cleaner look on cards
​
## What
​
This pull request introduces the following:
​Remove text decoration when hover
​
### Screenshot
![49vbjIE5Kp](https://user-images.githubusercontent.com/76784318/144348517-d9f5f13e-af54-4de1-8ccb-b8c71c5284e3.gif)
​